### PR TITLE
Updated register definition for WDOG_WCR_WT

### DIFF
--- a/Watchdog_t4.cpp
+++ b/Watchdog_t4.cpp
@@ -38,7 +38,7 @@ void watchdog_class::setTimeout(float val) {
   if ( val < 0.5f ) val = 0.5f;
   else if ( val > 128 ) val = 128;
   uint8_t value = (float)((  val / 0.5f) - 1);
-  WDOG1_WCR |= (WDOG1_WCR & ~WDOG_WCR_WT) | value << 8;
+  WDOG1_WCR |= (WDOG1_WCR & ~WDOG_WCR_WT(1)) | value << 8;
 }
 
 bool watchdog_class::setPin(uint8_t pin) {


### PR DESCRIPTION
It seems the header definition for WDOG_WCR_WT has changed. The reader imxrt.h that ships with arduinoteensy 1.51 defines the register like this:

`#define WDOG_WCR_WT(n)				((uint16_t)(((n) & 0xFF) << 8))`

I could compile the code again and have verified, that the watch dog triggers when I neglegt feeding it for 10s (given it has been initialized with setTimeout(10.0f)).